### PR TITLE
Add reram library path to git submodules init

### DIFF
--- a/sky130/README
+++ b/sky130/README
@@ -102,11 +102,12 @@ Prerequisites:
 	git submodule init libraries/sky130_fd_pr/latest
 	git submodule init libraries/sky130_fd_sc_hd/latest
 	git submodule init libraries/sky130_fd_sc_hvl/latest
+	[git submodule init libraries/sky130_fd_pr_reram/latest]
 	[git submodule init libraries/sky130_fd_sc_hdll/latest]
 	[git submodule init libraries/sky130_fd_sc_hs/latest]
 	[git submodule init libraries/sky130_fd_sc_ms/latest]
-	[git submodule init libraries/sky130_fd_sc_ls/latest]
 	[git submodule init libraries/sky130_fd_sc_lp/latest]
+	[git submodule init libraries/sky130_fd_sc_ls/latest]
 	git submodule update
 
     The liberty (.lib) files are the largest of all and so individual files


### PR DESCRIPTION
Added re-ram library path (as optional) in case someone wants to grab reram cells while doing a custom sky130B install